### PR TITLE
fix(nanvix): add INSTALL_PREFIX for CI-friendly sysroot packaging

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build
         run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" all
+          make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" INSTALL_PREFIX="/sysroot" all
 
       - name: Test
         run: |
@@ -103,20 +103,10 @@ jobs:
         run: |
           set -euo pipefail
           ARTIFACT_NAME="openssl-${{ matrix.platform }}-${{ matrix.process-mode }}"
-          DIST_DIR="dist/${ARTIFACT_NAME}"
-          mkdir -p "${DIST_DIR}/lib" "${DIST_DIR}/include/openssl"
-          # Copy libraries
-          cp -f libcrypto.a "${DIST_DIR}/lib/" 2>/dev/null || true
-          cp -f libssl.a "${DIST_DIR}/lib/" 2>/dev/null || true
-          # Copy provider libraries
-          mkdir -p "${DIST_DIR}/lib/ossl-modules"
-          cp -f providers/libcommon.a "${DIST_DIR}/lib/" 2>/dev/null || true
-          cp -f providers/libdefault.a "${DIST_DIR}/lib/" 2>/dev/null || true
-          cp -f providers/liblegacy.a "${DIST_DIR}/lib/" 2>/dev/null || true
-          # Copy headers
-          cp -f include/openssl/*.h "${DIST_DIR}/include/openssl/" 2>/dev/null || true
-          # Create tarball
-          tar -cjf "dist/${ARTIFACT_NAME}.tar.bz2" -C dist "${ARTIFACT_NAME}"
+          STAGING="$(pwd)/staging"
+          make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" install DESTDIR="$STAGING"
+          mkdir -p dist
+          tar -cjf "dist/${ARTIFACT_NAME}.tar.bz2" -C "$STAGING" sysroot
           echo "ARTIFACT_TARBALL=dist/${ARTIFACT_NAME}.tar.bz2" >> "$GITHUB_ENV"
 
       - name: Upload Build Artifacts

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -71,6 +71,11 @@ ifdef CONFIG_NANVIX
     TOOLCHAIN_PREFIX := $(NANVIX_TOOLCHAIN)
     SYSROOT_PATH := $(abspath $(NANVIX_HOME))
   endif
+
+  # INSTALL_PREFIX: the prefix baked into compiled artifacts (OPENSSLDIR, etc.).
+  # Local builds default to SYSROOT_PATH; CI overrides to /sysroot so that
+  # release artifacts don't contain ephemeral runner paths.
+  INSTALL_PREFIX ?= $(SYSROOT_PATH)
 else
   # Allow clean target without CONFIG_NANVIX
   ifneq ($(MAKECMDGOALS),clean)
@@ -91,8 +96,8 @@ CONFIGURE_ENV = \
 # Configure options for Nanvix
 # The 'nanvix' target is defined in Configurations/10-main.conf
 CONFIGURE_OPTS = \
-	--openssldir="$(SYSROOT_PATH)" \
-	--prefix="$(SYSROOT_PATH)" \
+	--openssldir="$(INSTALL_PREFIX)" \
+	--prefix="$(INSTALL_PREFIX)" \
 	nanvix \
 	no-shared \
 	threads \
@@ -160,11 +165,12 @@ distclean: clean
 	git clean -fdx -e Makefile.nanvix -e NANVIX.md -e .github -e nanvix-artifacts -e z 2>/dev/null || true
 
 # Install target (for Nanvix sysroot)
+# Use DESTDIR for staged installs: make install DESTDIR=/path/to/staging
 install: build
 ifdef CONFIG_NANVIX_DOCKER
-	$(DOCKER_RUN) make install_sw install_ssldirs
+	$(DOCKER_RUN) make install_sw install_ssldirs DESTDIR="$(DESTDIR)"
 else
-	make install_sw install_ssldirs
+	make install_sw install_ssldirs DESTDIR="$(DESTDIR)"
 endif
 
 .PHONY: all configure build clean distclean test install


### PR DESCRIPTION
## Summary

Adds `INSTALL_PREFIX` variable to `Makefile.nanvix` and updates CI workflow to support CI-friendly sysroot packaging.

## Changes
- **Makefile.nanvix**: Add configurable `INSTALL_PREFIX` to decouple the install destination from the build prefix, enabling CI to install into a staging sysroot
- **.github/workflows/nanvix-ci.yml**: Simplify CI workflow to use the new `INSTALL_PREFIX` mechanism

### Files Changed
2 files changed, 15 insertions(+), 19 deletions(-)