### PR TITLE
ci: include test ELFs in release packages

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -193,6 +193,7 @@ jobs:
           sysroot/
             lib/{libcrypto.a,libssl.a}
             include/openssl/{ssl.h,evp.h,...}
+            bin/openssl_nanvix_test.elf
           \`\`\`
 
           **Dependencies:** None (standalone library)" \

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -279,6 +279,8 @@ package: all
 	         dist/$(ARTIFACT_NAME)/sysroot/include/openssl
 	cp -f libcrypto.a libssl.a dist/$(ARTIFACT_NAME)/sysroot/lib/
 	cp -f include/openssl/*.h dist/$(ARTIFACT_NAME)/sysroot/include/openssl/
+	mkdir -p dist/$(ARTIFACT_NAME)/sysroot/bin
+	-cp -f $(TEST_ELF) dist/$(ARTIFACT_NAME)/sysroot/bin/ 2>/dev/null || true
 	tar -cjf dist/$(ARTIFACT_NAME).tar.bz2 -C dist/$(ARTIFACT_NAME) sysroot
 	@echo "  Package: dist/$(ARTIFACT_NAME).tar.bz2"
 	@echo "  Contents:"


### PR DESCRIPTION
Include `openssl_nanvix_test.elf` in `sysroot/bin/` of release packages so upstream verification can use pre-built test artifacts rather than compiling inline C programs.

- Add `sysroot/bin` directory and copy test ELF in `package` target
- Update CI workflow release notes to document `bin/openssl_nanvix_test.elf`