### PR TITLE
[zutils] E: Align zutil wrapper scripts with canonical versions

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 # If nanvix-zutil is already on PATH (e.g. CI), use it directly.
 if command -v nanvix-zutil &>/dev/null; then
-exec nanvix-zutil "$@"
+	exec nanvix-zutil "$@"
 fi
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
@@ -20,31 +20,31 @@ REPO_ROOT="$SCRIPT_DIR"
 VENV="$REPO_ROOT/.nanvix/venv"
 
 if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null; then
-# Pin nanvix-zutil version for reproducible bootstrapping.
-# Override with NANVIX_ZUTIL_VERSION env var if needed.
-ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.4.2}"
-echo "nanvix-zutil not found — bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
+	# Pin nanvix-zutil version for reproducible bootstrapping.
+	# Override with NANVIX_ZUTIL_VERSION env var if needed.
+	ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.4.2}"
+	echo "nanvix-zutil not found — bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
 
-if ! command -v python3 &>/dev/null; then
-echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
-exit 1
-fi
+	if ! command -v python3 &>/dev/null; then
+		echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
+		exit 1
+	fi
 
-WHEEL_URL="https://github.com/nanvix/zutils/releases/download/v${ZUTIL_VERSION}/nanvix_zutil-${ZUTIL_VERSION}-py3-none-any.whl"
-if [ -d "$VENV" ]; then
-python3 -m venv --clear "$VENV"
-else
-python3 -m venv "$VENV"
-fi
-"$VENV/bin/pip" install --quiet "$WHEEL_URL"
+	WHEEL_URL="https://github.com/nanvix/zutils/releases/download/v${ZUTIL_VERSION}/nanvix_zutil-${ZUTIL_VERSION}-py3-none-any.whl"
+	if [ -d "$VENV" ]; then
+		python3 -m venv --clear "$VENV"
+	else
+		python3 -m venv "$VENV"
+	fi
+	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
 fi
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 if [ -x "$VENV/bin/nanvix-zutil" ]; then
-exec "$VENV/bin/nanvix-zutil" "$@"
+	exec "$VENV/bin/nanvix-zutil" "$@"
 elif command -v nanvix-zutil &>/dev/null; then
-exec nanvix-zutil "$@"
+	exec nanvix-zutil "$@"
 else
-echo "nanvix-zutil not found in venv ($VENV) or on PATH." >&2
-exit 1
+	echo "nanvix-zutil not found in venv ($VENV) or on PATH." >&2
+	exit 1
 fi


### PR DESCRIPTION
Re-indent z.sh with tabs to match the canonical version used across
all nanvix/usr repositories.

- Re-indent z.sh with tabs for consistency across repositories