### PR TITLE
[ci] Sync zutils v0.6.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.2.0
     with:
-      zutil-version: "v0.5.1"
+      zutil-version: "v0.6.0"
       memory-sizes: '["128mb","256mb"]'
       caller-event-name: ${{ github.event_name }}
     secrets:

--- a/z
+++ b/z
@@ -10,7 +10,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 case "$(uname -s)" in
-    CYGWIN*|MINGW*|MSYS*)
+    CYGWIN* | MINGW* | MSYS*)
         exec powershell.exe -NoProfile -ExecutionPolicy Bypass \
             -File "$SCRIPT_DIR/z.ps1" "$@"
         ;;

--- a/z.ps1
+++ b/z.ps1
@@ -34,38 +34,62 @@ catch {
 function Bootstrap {
     # Pin nanvix-zutil version for reproducible bootstrapping.
     # Override with NANVIX_ZUTIL_VERSION env var if needed.
-    Write-Host "nanvix-zutil not found — bootstrapping nanvix-zutil==${zutilVersion}..." -ForegroundColor Yellow
+    Write-Information "nanvix-zutil not found -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
 
     $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
 
     # Discover a Python 3 interpreter.
+    $venvArgs = @("-m", "venv")
+    if (Test-Path $venvDir) { $venvArgs += "--clear" }
+    $venvArgs += $venvDir
+
     if (Get-Command py -ErrorAction SilentlyContinue) {
-        & py -3 -m venv $venvDir
+        & py -3 @venvArgs
     }
     elseif (Get-Command python -ErrorAction SilentlyContinue) {
-        & python -m venv $venvDir
+        & python @venvArgs
     }
     elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
-        & python3 -m venv $venvDir
+        & python3 @venvArgs
     }
     else {
         throw "Python 3 not found. Install Python 3 and ensure py, python, or python3 is on PATH."
     }
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        throw "venv creation failed (exit code $LASTEXITCODE)"
+    }
     & $venvPython -m pip install --quiet $wheelUrl
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        throw "pip install failed (exit code $LASTEXITCODE)"
+    }
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 $bin = $null
 if ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
     Bootstrap
+    if (-not (Test-Path $venvZutil)) {
+        throw "Bootstrap completed but $venvZutil not found."
+    }
     $bin = $venvZutil
 }
 elseif (Test-Path $venvZutil) {
+    $venvVersion = try { & $venvZutil --version 2>$null } catch { $null }
+    if ($venvVersion -ne "nanvix-zutil ${zutilVersion}") {
+        Write-Warning "Venv nanvix-zutil version mismatch. Expected ${zutilVersion}, found ${venvVersion}. Re-bootstrapping..."
+        Bootstrap
+        if (-not (Test-Path $venvZutil)) {
+            throw "Bootstrap completed but $venvZutil not found."
+        }
+    }
     $bin = $venvZutil
 }
 elseif ((Test-Path $venvDir) -and (-not $zutilGlobalVersion)) {
     Write-Warning "Incomplete venv detected (binary missing). Re-running bootstrap..."
     Bootstrap
+    if (-not (Test-Path $venvZutil)) {
+        throw "Bootstrap completed but $venvZutil not found."
+    }
     $bin = $venvZutil
 }
 else {

--- a/z.sh
+++ b/z.sh
@@ -11,25 +11,25 @@ ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.5.1}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
 VENV_BIN="$VENV/bin/nanvix-zutil"
-ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true )"
+ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 
 function bootstrap() {
-	# Pin nanvix-zutil version for reproducible bootstrapping.
-	# Override with NANVIX_ZUTIL_VERSION env var if needed.
-	echo "nanvix-zutil not found — bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
+    # Pin nanvix-zutil version for reproducible bootstrapping.
+    # Override with NANVIX_ZUTIL_VERSION env var if needed.
+    echo "nanvix-zutil not found -- bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
 
-	if ! command -v python3 &>/dev/null; then
-		echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
-		exit 1
-	fi
+    if ! command -v python3 &>/dev/null; then
+        echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
+        exit 1
+    fi
 
-	WHEEL_URL="https://github.com/nanvix/zutils/releases/download/v${ZUTIL_VERSION}/nanvix_zutil-${ZUTIL_VERSION}-py3-none-any.whl"
-	if [ -d "$VENV" ]; then
-		python3 -m venv --clear "$VENV"
-	else
-		python3 -m venv "$VENV"
-	fi
-	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
+    WHEEL_URL="https://github.com/nanvix/zutils/releases/download/v${ZUTIL_VERSION}/nanvix_zutil-${ZUTIL_VERSION}-py3-none-any.whl"
+    if [ -d "$VENV" ]; then
+        python3 -m venv --clear "$VENV"
+    else
+        python3 -m venv "$VENV"
+    fi
+    "$VENV/bin/pip" install --quiet "$WHEEL_URL"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.
@@ -38,6 +38,11 @@ if [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
     bootstrap
     BIN="$VENV_BIN"
 elif [ -x "$VENV_BIN" ]; then
+    VENV_VERSION="$("$VENV_BIN" --version 2>/dev/null || true)"
+    if [ "$VENV_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
+        echo "Warning: venv nanvix-zutil version mismatch. Expected ${ZUTIL_VERSION}, found ${VENV_VERSION}. Re-bootstrapping..." >&2
+        bootstrap
+    fi
     BIN="$VENV_BIN"
 elif [ -d "$VENV" ] && ! command -v nanvix-zutil &>/dev/null; then
     echo "Warning: incomplete venv detected (binary missing). Re-running bootstrap..." >&2


### PR DESCRIPTION
Automated sync with [`v0.6.0`](https://github.com/nanvix/zutils/releases/tag/v0.6.0):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.