### PR TITLE
[ci] Sync zutils v0.7.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.4.0
     with:
-      zutil-version: "v0.6.0"
+      zutil-version: "v0.7.0"
       memory-sizes: '["128mb","256mb"]'
       caller-event-name: ${{ github.event_name }}
     secrets:


### PR DESCRIPTION
Automated sync with [`v0.7.0`](https://github.com/nanvix/zutils/releases/tag/v0.7.0):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.