### PR TITLE
[ci] E: Temporarily route workflow_dispatch to schedule path

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   ci:
-    if: github.event_name != 'schedule'
+    if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.4.0
     with:
       zutil-version: "v0.7.3"
@@ -33,7 +33,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
   ci-scheduled:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
       actions: write
@@ -43,6 +43,6 @@ jobs:
     with:
       zutil-version: "v0.7.3"
       memory-sizes: '["128mb","256mb"]'
-      caller-event-name: ${{ github.event_name }}
+      caller-event-name: 'schedule'
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Routes workflow_dispatch to ci-scheduled job to test the schedule code path. Reverts needed after validation.