### PR TITLE
[ci] Sync zutils v0.7.14

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.5.0
     with:
-      zutil-version: "v0.7.13"
+      zutil-version: "v0.7.14"
       memory-sizes: '["128mb","256mb"]'
       caller-event-name: ${{ github.event_name }}
     secrets:
@@ -42,7 +42,7 @@ jobs:
       pull-requests: write
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.5.0
     with:
-      zutil-version: "v0.7.13"
+      zutil-version: "v0.7.14"
       memory-sizes: '["128mb","256mb"]'
       caller-event-name: 'schedule'
     secrets:

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.13"
+    "0.7.14"
 }
 
 # z.ps1 lives at the repository root, so use its directory directly

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.13"
+PINNED_VERSION="0.7.14"
 ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"


### PR DESCRIPTION
Automated sync with [`v0.7.14`](https://github.com/nanvix/zutils/releases/tag/v0.7.14):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.