### PR TITLE
fix(z.py): translate sysroot/toolchain paths for Docker mode

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -47,12 +47,14 @@ class OpenSSLBuild(ZScript):
                 hint="Run `./z setup` first to download the sysroot.",
             )
         toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
+        sysroot_p = self.translate_path(Path(sysroot))
+        toolchain_p = self.translate_path(Path(toolchain))
 
         args = [
             "make", "-f", "Makefile.nanvix",
             f"{_MAKE_VAR_CONFIG}=y",
-            f"{_MAKE_VAR_HOME}={sysroot}",
-            f"{_MAKE_VAR_TOOLCHAIN}={toolchain}",
+            f"{_MAKE_VAR_HOME}={sysroot_p}",
+            f"{_MAKE_VAR_TOOLCHAIN}={toolchain_p}",
         ]
 
         args.extend([


### PR DESCRIPTION
Use `self.translate_path()` in `_make_args()` so that host paths are correctly mapped to container paths when Docker wrapping is active.

Without this, `make` receives host-side paths (e.g. `/home/.../sysroot`) that do not exist inside the Docker container (where the sysroot is mounted at `/mnt/sysroot`), causing build failures.

This is a companion fix to [nanvix/zutils#130](https://github.com/nanvix/zutils/pull/130) which moved Docker flags to subcommand level.
