### PR TITLE
fix: remove .PHONY build prerequisite from test targets

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -209,7 +209,7 @@ $(TEST_SRC):
 	  '}' > $@
 
 # Build the test program
-$(TEST_ELF): $(TEST_SRC) build
+$(TEST_ELF): $(TEST_SRC) libcrypto.a libssl.a
 ifdef CONFIG_NANVIX_DOCKER
 	$(DOCKER_RUN) $(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-gcc -O2 \
 	  -I$(DOCKER_WORKSPACE_PATH)/include \
@@ -227,7 +227,7 @@ else
 endif
 
 # --- Smoke tests: verify build artifacts (no runtime needed) ---
-test-smoke: build
+test-smoke:
 	@echo "=== openssl smoke tests ==="
 	@echo "  Checking libcrypto.a..."
 	@test -f libcrypto.a || { echo "  FAIL: libcrypto.a not found"; exit 1; }


### PR DESCRIPTION
test-smoke and the test ELF rule depended on the .PHONY target build, which always re-executes its recipe. After a Docker build, the generated configdata.pm contains container paths (/mnt/workspace/util/perl) that do not exist on the host, causing make test to fail when running natively.

**Fix:** Remove build from test-smoke prerequisites and replace it with libcrypto.a libssl.a in the test ELF rule. The build lifecycle phase always runs before test, and the test recipes validate artifact existence themselves.

Part of nanvix/zutils#130.