### PR TITLE
fix(Makefile.nanvix): use absolute path for nanvixd binary argument

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -262,7 +262,7 @@ ifdef CONFIG_NANVIX_DOCKER
 	  ./bin/mkramfs.elf -o /tmp/rootfs.img /tmp/nanvix-ramfs/ && \
 	  timeout --foreground 120 ./bin/nanvixd.elf \
 	    -bin-dir ./bin -ramfs /tmp/rootfs.img \
-	    -- ./$(TEST_ELF)'
+	    -- $(abspath $(TEST_ELF))'
 	@echo "  PASS: openssl library test standalone (exit code 0)"
 else
 	@echo "  Running $(TEST_ELF) via nanvixd.elf standalone..."
@@ -271,7 +271,7 @@ else
 	"$(SYSROOT_PATH)/bin/mkramfs.elf" -o /tmp/rootfs.img /tmp/nanvix-ramfs/
 	cd "$(SYSROOT_PATH)" && timeout --foreground 120 ./bin/nanvixd.elf \
 	  -bin-dir ./bin -ramfs /tmp/rootfs.img \
-	  -- ./$(TEST_ELF)
+	  -- $(abspath $(TEST_ELF))
 	@rm -rf /tmp/nanvix-ramfs /tmp/rootfs.img
 	@echo "  PASS: openssl library test standalone (exit code 0)"
 endif


### PR DESCRIPTION
nanvixd uses mmap() to load the user binary from the host filesystem path given after `--`. The standalone non-Docker test recipe does `cd $(SYSROOT_PATH)` before invoking nanvixd, so `./binary.elf` resolves relative to the sysroot — where the binary does not exist.

Replace relative paths with `$(abspath ...)` so nanvixd can find the binary regardless of the working directory. The non-standalone recipes already used `$(abspath ...)` correctly.

Part of nanvix/zutils#130.