### PR TITLE
[ci] E: Pin nanvix to v0.12.467

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openssl"
 version = "3.5.0"
-nanvix-version = "0.12.461"
+nanvix-version = "0.12.467"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated bump of `nanvix-version` to [`v0.12.467`](https://github.com/nanvix/nanvix/releases/tag/v0.12.467).