### PR TITLE
[ci] E: Update nanvix workflow refs to v1.13.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.12.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
     with:
       zutil-version: "v0.7.26"
       platforms: '["hyperlight","microvm"]'
@@ -45,7 +45,7 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.12.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
     with:
       zutil-version: "v0.7.26"
       platforms: '["hyperlight","microvm"]'


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v1.13.0`](https://github.com/nanvix/workflows/releases/tag/v1.13.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.