### PR TITLE
ci: bump nanvix/workflows to v1.14.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
       zutil-version: "v0.7.42"
       platforms: '["hyperlight","microvm"]'
@@ -47,7 +47,7 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
       zutil-version: "v0.7.42"
       platforms: '["hyperlight","microvm"]'


### PR DESCRIPTION
Bumps `nanvix/workflows` from `v1.13.0` to `v1.14.0`, which adds format & lint checks (black, pyright, shfmt, shellcheck, yamllint) to the `nanvix-ci.yml` reusable workflow.

All consumers automatically gain these checks with no other changes needed.