### PR TITLE
chore: migrate Docker image to ghcr.io/nanvix/toolchain-gcc

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -21,7 +21,7 @@
 # It wraps the OpenSSL ./Configure build system with Nanvix cross-compilation settings.
 
 # Nanvix Docker image for cross-compilation (used as fallback if native toolchain not found)
-NANVIX_DOCKER_IMAGE ?= nanvix/toolchain:latest-minimal
+NANVIX_DOCKER_IMAGE ?= ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 
 # Nanvix cross-compilation configuration
 ifdef CONFIG_NANVIX
@@ -34,13 +34,14 @@ ifdef CONFIG_NANVIX
       # Native toolchain not found, check for Docker
       DOCKER_AVAILABLE := $(shell command -v docker 2>/dev/null)
       ifdef DOCKER_AVAILABLE
-        DOCKER_IMAGE_EXISTS := $(shell docker image inspect $(NANVIX_DOCKER_IMAGE) >/dev/null 2>&1 && echo yes)
+        DOCKER_IMAGE_EXISTS := $(shell docker image inspect $(NANVIX_DOCKER_IMAGE) >/dev/null 2>&1 && echo yes || \
+          { docker pull $(NANVIX_DOCKER_IMAGE) >/dev/null 2>&1 && echo yes; })
         ifdef DOCKER_IMAGE_EXISTS
           # Use Docker for cross-compilation
           CONFIG_NANVIX_DOCKER := y
           $(info [nanvix] Using Docker (native toolchain not found at $(NANVIX_TOOLCHAIN)))
         else
-          $(error Docker image $(NANVIX_DOCKER_IMAGE) not found. Run: docker pull $(NANVIX_DOCKER_IMAGE))
+          $(error Docker image $(NANVIX_DOCKER_IMAGE) not found and pull failed. Run: docker pull $(NANVIX_DOCKER_IMAGE))
         endif
       else
         $(error Nanvix toolchain not found at $(NANVIX_TOOLCHAIN) and Docker is not available)
@@ -52,9 +53,10 @@ ifdef CONFIG_NANVIX
     ifndef DOCKER_AVAILABLE
       $(error CONFIG_NANVIX_DOCKER=y but Docker is not installed)
     endif
-    DOCKER_IMAGE_EXISTS := $(shell docker image inspect $(NANVIX_DOCKER_IMAGE) >/dev/null 2>&1 && echo yes)
+    DOCKER_IMAGE_EXISTS := $(shell docker image inspect $(NANVIX_DOCKER_IMAGE) >/dev/null 2>&1 && echo yes || \
+      { docker pull $(NANVIX_DOCKER_IMAGE) >/dev/null 2>&1 && echo yes; })
     ifndef DOCKER_IMAGE_EXISTS
-      $(error Docker image $(NANVIX_DOCKER_IMAGE) not found. Run: docker pull $(NANVIX_DOCKER_IMAGE))
+      $(error Docker image $(NANVIX_DOCKER_IMAGE) not found and pull failed. Run: docker pull $(NANVIX_DOCKER_IMAGE))
     endif
     $(info [nanvix] Using Docker (explicitly requested))
   endif
@@ -69,6 +71,21 @@ ifdef CONFIG_NANVIX
     DOCKER_WORKSPACE_PATH := /mnt/workspace
     DOCKER_UID := $(shell id -u)
     DOCKER_GID := $(shell id -g)
+    # Install build deps (Perl) needed by OpenSSL Configure/build scripts.
+    # Conditional: skip if perl is already usable (e.g. derived images).
+    DOCKER_DEPS := if ! perl -MFindBin -e1 >/dev/null 2>&1; then \
+      DEBIAN_FRONTEND=noninteractive apt-get update -qq >/dev/null && \
+      apt-get install -y -qq perl >/dev/null; fi
+    # Ownership fixup (runs via trap so it executes even on failure)
+    DOCKER_CHOWN := chown -R $(DOCKER_UID):$(DOCKER_GID) .
+    # Root invocation for steps that need to install packages
+    DOCKER_RUN_ROOT := docker run --rm \
+      -v $(CURDIR):$(DOCKER_WORKSPACE_PATH) \
+      -v $(abspath $(NANVIX_HOME)):$(DOCKER_SYSROOT_PATH):ro \
+      -w $(DOCKER_WORKSPACE_PATH) \
+      -e HOME=/tmp \
+      $(NANVIX_DOCKER_IMAGE)
+    # User invocation for steps that only need the toolchain
     DOCKER_RUN := docker run --rm --user $(DOCKER_UID):$(DOCKER_GID) \
       -v $(CURDIR):$(DOCKER_WORKSPACE_PATH) \
       -v $(abspath $(NANVIX_HOME)):$(DOCKER_SYSROOT_PATH):ro \
@@ -164,7 +181,7 @@ configure: $(CONFIGURED_MARKER)
 $(CONFIGURED_MARKER):
 ifdef CONFIG_NANVIX_DOCKER
 	@echo "Running Configure inside Docker..."
-	$(DOCKER_RUN) sh -c '$(CONFIGURE_ENV) ./Configure $(CONFIGURE_OPTS)'
+	$(DOCKER_RUN_ROOT) sh -c 'trap "$(DOCKER_CHOWN)" EXIT; $(DOCKER_DEPS) && $(CONFIGURE_ENV) ./Configure $(CONFIGURE_OPTS)'
 else
 	$(CONFIGURE_ENV) ./Configure $(CONFIGURE_OPTS)
 endif
@@ -174,7 +191,7 @@ endif
 build: $(CONFIGURED_MARKER)
 ifdef CONFIG_NANVIX_DOCKER
 	@echo "Building inside Docker..."
-	$(DOCKER_RUN) make -j$$(nproc) all
+	$(DOCKER_RUN_ROOT) sh -c 'trap "$(DOCKER_CHOWN)" EXIT; $(DOCKER_DEPS) && make -j$$(nproc) all'
 else
 	make -j$$(nproc) all
 endif
@@ -340,7 +357,7 @@ verify-package:
 
 install: build
 ifdef CONFIG_NANVIX_DOCKER
-	$(DOCKER_RUN) make install_sw install_ssldirs DESTDIR="$(DESTDIR)"
+	$(DOCKER_RUN_ROOT) sh -c 'trap "$(DOCKER_CHOWN)" EXIT; $(DOCKER_DEPS) && make install_sw install_ssldirs DESTDIR="$(DESTDIR)"'
 else
 	make install_sw install_ssldirs DESTDIR="$(DESTDIR)"
 endif

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -61,7 +61,9 @@ Or build directly with Make (advanced):
 
 ```bash
 # 1. Pull the Docker image
-docker pull nanvix/toolchain:latest-minimal
+docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
+# NOTE: If the image is private or you hit rate limits, authenticate first:
+#   docker login ghcr.io
 
 # 2. Download Nanvix sysroot
 curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- nanvix-artifacts
@@ -132,7 +134,7 @@ The Makefile supports automatic Docker fallback when the native toolchain is not
 
 ```bash
 # Pull the Nanvix toolchain Docker image
-docker pull nanvix/toolchain:latest-minimal
+docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 
 # Build (Docker is used automatically if native toolchain is not found)
 make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debug
@@ -142,9 +144,10 @@ make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debu
 
 **Docker Fallback Behavior:**
 - If `NANVIX_TOOLCHAIN` points to a valid toolchain, it uses the native compiler
-- If the native toolchain is not found, it automatically uses Docker if available
+- If the native toolchain is not found, it automatically uses Docker if available (auto-pulls the image if needed)
 - Use `CONFIG_NANVIX_DOCKER=y` to force Docker usage even when native toolchain exists
-- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `nanvix/toolchain:latest-minimal`)
+- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `ghcr.io/nanvix/toolchain-gcc:sha-34a3641`)
+- GHCR may require authentication (`docker login ghcr.io`) if the image is private or rate-limited
 
 ### Using Native Toolchain
 


### PR DESCRIPTION
Closes #171

## Summary

Migrate the cross-compilation Docker image from `nanvix/toolchain:latest-minimal` (Docker Hub) to `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` (GHCR).

## Changes

- **Makefile.nanvix**: Update default `NANVIX_DOCKER_IMAGE`; add `DOCKER_RUN_ROOT` for steps that need to install Perl (the new minimal image only ships `perl-base`, but OpenSSL Configure/build needs full `perl`)
- **NANVIX.md**: Update `docker pull` instructions and default image docs
- **.nanvix/env.json**: Update local `NANVIX_DOCKER_IMAGE` (gitignored)

## Testing

All test levels pass locally with the new image:
- ✅ Smoke tests (library artifacts)
- ✅ Integration tests (cross-compiled test binary)
- ✅ Functional tests (ran `openssl_nanvix_test.elf` on `nanvixd.elf` via KVM)