### PR TITLE
[ci] E: Update nanvix workflow refs to v1.15.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
     with:
       zutil-version: "v0.7.48"
       platforms: '["microvm"]'
@@ -46,7 +46,7 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
     with:
       zutil-version: "v0.7.48"
       platforms: '["microvm"]'

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -30,12 +30,71 @@ _MAKE_VAR_INSTALL_PREFIX = "INSTALL_PREFIX"
 # Use /sysroot so that release tarballs don't contain ephemeral runner paths.
 _DEFAULT_INSTALL_PREFIX = "/sysroot"
 
+# Docker image for cross-compilation (must match Makefile.nanvix default).
+_DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"
+
 
 IS_WINDOWS = sys.platform == "win32"
 
 
 class OpenSSLBuild(ZScript):
     """Build script for nanvix/openssl."""
+
+    def docker_image(self) -> str:
+        """Return the Docker image for cross-compilation."""
+        return _DOCKER_IMAGE
+
+    def _ensure_docker_perl(self) -> None:
+        """Ensure the Docker image has Perl with FindBin (needed by Configure).
+
+        The base toolchain image ships only ``perl-base``.  OpenSSL's
+        ``./Configure`` requires the full ``perl`` package (``FindBin``).
+        When Docker is active, this method builds a thin derived image
+        that adds ``perl`` on top of the base image, then switches
+        ``self.docker`` to use it.  The derived image is cached locally
+        so subsequent calls are instant.
+        """
+        if not self.docker:
+            return
+
+        base = self.docker.image
+        derived = f"{base}-openssl"
+
+        # Fast path: derived image already built from a previous run.
+        if (
+            subprocess.run(
+                ["docker", "image", "inspect", derived],
+                capture_output=True,
+            ).returncode
+            == 0
+        ):
+            self.docker = self.docker_config(derived)
+            return
+
+        # Check whether the base image already ships FindBin.
+        if (
+            subprocess.run(
+                ["docker", "run", "--rm", base, "perl", "-MFindBin", "-e1"],
+                capture_output=True,
+            ).returncode
+            == 0
+        ):
+            return
+
+        # Build a derived image that adds perl.
+        log.info("Building derived Docker image with Perl (required by OpenSSL)...")
+        subprocess.run(
+            ["docker", "build", "-t", derived, "-"],
+            input=(
+                f"FROM {base}\n"
+                "RUN apt-get update -qq && "
+                "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq perl bzip2 && "
+                "rm -rf /var/lib/apt/lists/*\n"
+            ),
+            text=True,
+            check=True,
+        )
+        self.docker = self.docker_config(derived)
 
     def _make_args(self, *targets: str, with_install_prefix: bool = True) -> list[str]:
         """Build the common make argument list."""
@@ -79,6 +138,7 @@ class OpenSSLBuild(ZScript):
 
     def build(self) -> None:
         """Cross-compile libcrypto.a and libssl.a for Nanvix."""
+        self._ensure_docker_perl()
         self.run(*self._make_args("all"), cwd=self.repo_root)
 
     def test(self) -> None:
@@ -91,6 +151,7 @@ class OpenSSLBuild(ZScript):
         if IS_WINDOWS:
             self._run_tests_windows()
             return
+        self._ensure_docker_perl()
         targets = self.targets if self.targets else ["test"]
         self.run(*self._make_args(*targets), cwd=self.repo_root)
 
@@ -193,6 +254,7 @@ class OpenSSLBuild(ZScript):
 
     def release(self) -> None:
         """Package the OpenSSL release tarball and verify it."""
+        self._ensure_docker_perl()
         self.run(*self._make_args("package"), cwd=self.repo_root)
         self.run(*self._make_args("verify-package"), cwd=self.repo_root)
 


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v1.15.0`](https://github.com/nanvix/workflows/releases/tag/v1.15.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.