### PR TITLE
[ci] E: Pin nanvix to v0.14.13

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openssl"
 version = "3.5.0"
-nanvix-version = "0.14.12"
+nanvix-version = "0.14.13"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated bump of `nanvix-version` to [`v0.14.13`](https://github.com/nanvix/nanvix/releases/tag/v0.14.13).

Generated by the [Nanvix CI](https://github.com/nanvix/workflows/blob/main/.github/workflows/nanvix-ci.yml) reusable workflow.