### PR TITLE
[build] E: Build libcrypto.so + libssl.so alongside static archives

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -14,8 +14,10 @@ Usage:
 from __future__ import annotations
 
 import dataclasses
+import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 from pathlib import Path
 
@@ -29,15 +31,6 @@ from nanvix_zutil import (
     log,
     make_initrd,
     run,
-)
-from nanvix_zutil.paths import (
-    dist_dir,
-    include_out,
-    lib_out,
-    nanvix_root,
-    out_dir,
-    repo_root,
-    test_out,
 )
 
 _EXIT_BUILD: int = EXIT_BUILD_FAILURE
@@ -62,9 +55,10 @@ _DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"
 _TEST_ELF = "openssl_nanvix_test.elf"
 
 # Public headers generated from ``include/openssl/*.h.in`` templates by
-# OpenSSL's ``Configure`` step.  Listed for documentation and for
-# inclusion in the install-staged release tree (the install rule globs
-# ``include/openssl/*.h`` so the list is informational here).
+# OpenSSL's ``Configure`` step. These are not present in the source tree
+# and must be copied back from the container after the build so that
+# host-side release packaging (which ships every ``include/openssl/*.h``)
+# produces complete tarballs.
 _GENERATED_HEADERS: list[str] = [
     "asn1.h",
     "asn1t.h",
@@ -97,13 +91,17 @@ _GENERATED_HEADERS: list[str] = [
 ]
 
 # Files produced inside the Docker tar-copy build dir (Windows path) that
-# must be copied back to the host workspace.  Only the test ELF is needed
-# at the repo root post-build: it is the test target's input and is
-# resolved by ``make_initrd`` relative to ``repo_root()``.  Release-staged
-# artifacts (libraries, headers, test ELF copy) are covered by
-# ``_staged_output_files()``.
+# must be copied back to the host workspace so subsequent host-side steps
+# (tests, release packaging) can find them. Paths are relative to the
+# workspace root (i.e. ``/tmp/build`` inside the container, ``repo_root``
+# on the host).
 _BUILD_OUTPUTS: list[str] = [
+    "libcrypto.a",
+    "libssl.a",
+    "libcrypto.so",
+    "libssl.so",
     _TEST_ELF,
+    *(f"include/openssl/{h}" for h in _GENERATED_HEADERS),
 ]
 
 IS_WINDOWS = sys.platform == "win32"
@@ -127,26 +125,7 @@ class OpenSSLBuild(ZScript):
         itself is the build directory).
         """
         cfg = super().docker_config(image)
-        return dataclasses.replace(
-            cfg,
-            output_files=list(_BUILD_OUTPUTS) + self._staged_output_files(),
-        )
-
-    def _staged_output_files(self) -> list[str]:
-        """Return install-staged artifact paths (relative to repo_root())
-        so Windows tar-copy mode also copies them back to the host.
-        """
-        root = repo_root()
-        staged: list[str] = [
-            str((lib_out() / "libcrypto.a").relative_to(root)),
-            str((lib_out() / "libssl.a").relative_to(root)),
-            str((test_out() / _TEST_ELF).relative_to(root)),
-        ]
-        staged.extend(
-            str((include_out() / "openssl" / h).relative_to(root))
-            for h in _GENERATED_HEADERS
-        )
-        return staged
+        return dataclasses.replace(cfg, output_files=list(_BUILD_OUTPUTS))
 
     def _ensure_docker_perl(self) -> None:
         """Ensure the Docker image has Perl with FindBin (needed by Configure).
@@ -225,9 +204,6 @@ class OpenSSLBuild(ZScript):
             self.docker.translate_path(Path(sysroot)) if self.docker else Path(sysroot)
         )
 
-        def translate(p: Path):
-            return self.docker.translate_path(p) if self.docker else p
-
         args = [
             "make",
             "-f",
@@ -241,12 +217,6 @@ class OpenSSLBuild(ZScript):
                 f"{_MAKE_VAR_PLATFORM}={self.config.machine}",
                 f"{_MAKE_VAR_PROCESS_MODE}={self.config.deployment_mode}",
                 f"{_MAKE_VAR_MEMORY_SIZE}={self.config.memory_size}",
-                f"NANVIX_ROOT={translate(nanvix_root())}",
-                f"OUT_DIR={translate(out_dir())}",
-                f"DIST_DIR={translate(dist_dir())}",
-                f"LIB_OUT={translate(lib_out())}",
-                f"INCLUDE_OUT={translate(include_out())}",
-                f"TEST_OUT={translate(test_out())}",
             ]
         )
 
@@ -270,7 +240,7 @@ class OpenSSLBuild(ZScript):
         # Build libraries and test binary in one pass.
         run(
             *self._make_args("all", _TEST_ELF),
-            cwd=repo_root(),
+            cwd=self.repo_root,
             docker=self.docker,
         )
 
@@ -294,6 +264,67 @@ class OpenSSLBuild(ZScript):
         self._require_build_artifacts()
         self._run_functional_standalone()
 
+    def release(self) -> None:
+        """Package the release tarball natively (no Docker).
+
+        Uses Python's tarfile module for gzip compression.
+        """
+        repo = self.repo_root
+        libcrypto = repo / "libcrypto.a"
+        libssl = repo / "libssl.a"
+        libcrypto_so = repo / "libcrypto.so"
+        libssl_so = repo / "libssl.so"
+        headers_dir = repo / "include" / "openssl"
+        test_elf = repo / _TEST_ELF
+
+        for path in (libcrypto, libssl, libcrypto_so, libssl_so, headers_dir):
+            if not path.exists():
+                log.fatal(
+                    f"release: missing artefact {path}",
+                    code=_EXIT_BUILD,
+                    hint="Run `./z build` first.",
+                )
+
+        artifact = (
+            f"openssl-{self.config.machine}"
+            f"-{self.config.deployment_mode}"
+            f"-{self.config.memory_size}"
+        )
+        dist_dir = repo / "dist"
+        staging = dist_dir / artifact
+        sysroot = staging / "sysroot"
+
+        # Fresh stage every time.
+        if staging.exists():
+            shutil.rmtree(staging)
+        (sysroot / "lib").mkdir(parents=True)
+        (sysroot / "include" / "openssl").mkdir(parents=True)
+        (sysroot / "bin").mkdir(parents=True)
+
+        # Copy libraries.
+        shutil.copy2(libcrypto, sysroot / "lib" / "libcrypto.a")
+        shutil.copy2(libssl, sysroot / "lib" / "libssl.a")
+        shutil.copy2(libcrypto_so, sysroot / "lib" / "libcrypto.so")
+        shutil.copy2(libssl_so, sysroot / "lib" / "libssl.so")
+
+        # Copy headers.
+        for h in sorted(headers_dir.glob("*.h")):
+            shutil.copy2(h, sysroot / "include" / "openssl" / h.name)
+
+        # Copy test ELF if available.
+        if test_elf.is_file():
+            shutil.copy2(test_elf, sysroot / "bin" / test_elf.name)
+
+        # Build gzip-compressed tarball using Python's tarfile module.
+        tarball = dist_dir / f"{artifact}.tar.gz"
+        if tarball.exists():
+            tarball.unlink()
+        with tarfile.open(tarball, "w:gz") as tf:
+            tf.add(sysroot, arcname="sysroot")
+        log.info(f"Wrote release tarball: {tarball}")
+
+        self._verify_release(tarball)
+
     def clean(self) -> None:
         """Remove build artifacts."""
         run(
@@ -301,7 +332,7 @@ class OpenSSLBuild(ZScript):
             "-f",
             "Makefile.nanvix",
             "clean",
-            cwd=repo_root(),
+            cwd=self.repo_root,
         )
 
     # ------------------------------------------------------------------
@@ -316,7 +347,7 @@ class OpenSSLBuild(ZScript):
         (Linux/Windows, microvm/standalone) and points the user at the
         right remediation without needing to parse make output.
         """
-        elf = repo_root() / _TEST_ELF
+        elf = self.repo_root / _TEST_ELF
         if not elf.is_file():
             log.fatal(
                 f"test: missing build artefact: {_TEST_ELF}",
@@ -334,7 +365,7 @@ class OpenSSLBuild(ZScript):
         Creates an initrd bundling the test ELF with system daemons via
         make_initrd, and a ramfs providing /tmp for test I/O.
         """
-        elf = repo_root() / _TEST_ELF
+        elf = self.repo_root / _TEST_ELF
         if not elf.is_file():
             log.fatal(
                 f"{_TEST_ELF} not found.",
@@ -359,7 +390,7 @@ class OpenSSLBuild(ZScript):
         log.info("=== openssl functional tests ===")
         log.info(f"  Running {_TEST_ELF} via nanvixd standalone...")
 
-        initrd = make_initrd(self, _TEST_ELF, test=True)
+        initrd = make_initrd(self, _TEST_ELF)
         try:
             with tempfile.TemporaryDirectory(prefix="openssl_test_") as tmp:
                 tmp_path = Path(tmp)
@@ -406,6 +437,38 @@ class OpenSSLBuild(ZScript):
                 hint="Run `./z setup` first.",
             )
         return Path(sysroot)
+
+    # ------------------------------------------------------------------
+    # Release verification
+    # ------------------------------------------------------------------
+
+    def _verify_release(self, tarball: Path) -> None:
+        """Verify the release tarball contains expected paths."""
+        required = {
+            "sysroot/lib/libcrypto.a",
+            "sysroot/lib/libssl.a",
+            "sysroot/lib/libcrypto.so",
+            "sysroot/lib/libssl.so",
+        }
+        with tarfile.open(tarball, "r:gz") as tf:
+            members = set(tf.getnames())
+        missing = sorted(required - members)
+        if missing:
+            log.fatal(
+                f"release: tarball missing required paths: {missing}",
+                code=_EXIT_BUILD,
+                hint=f"Tarball: {tarball}",
+            )
+        if not any(
+            m.startswith("sysroot/include/openssl/") and m != "sysroot/include/openssl"
+            for m in members
+        ):
+            log.fatal(
+                "release: tarball has no entries under sysroot/include/openssl/",
+                code=_EXIT_BUILD,
+                hint=f"Tarball: {tarball}",
+            )
+        log.info(f"Verified release tarball: {tarball}")
 
 
 if __name__ == "__main__":

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -6,8 +6,7 @@
 #    [INSTALL_PREFIX=<prefix>] [target]
 #
 # Targets:
-#   all              Build static libraries (libcrypto.a, libssl.a) and test ELF, then stage via install
-#   install          Stage built artifacts into LIB_OUT/INCLUDE_OUT/TEST_OUT
+#   all              Build static libraries (libcrypto.a, libssl.a) and test ELF
 #   clean            Remove build artifacts
 #
 # Note: the functional test (boot the test ELF under nanvixd) is driven
@@ -30,24 +29,24 @@ EXE = .elf
 TEST_SRC := openssl_nanvix_test.c
 TEST_ELF := openssl_nanvix_test$(EXE)
 
+# Shared library outputs.  Linked from the static archives via
+# `--whole-archive` after stripping the bss_log.o member that
+# references unimplemented POSIX `openlog`/`syslog`/`closelog`
+# (Nanvix newlib does not implement the syslog client API;
+# OpenSSL's BIO_s_log -- which we don't use -- is the only
+# consumer).
+LIBCRYPTO_SO := libcrypto.so
+LIBSSL_SO    := libssl.so
+
 # Marker file produced by ./Configure.
 CONFIGURED_MARKER := .nanvix-configured
 
-_NANVIX_DOCKER_BUILD_GOALS := all build install $(CONFIGURED_MARKER) $(TEST_ELF)
+_NANVIX_DOCKER_BUILD_GOALS := all build $(CONFIGURED_MARKER) $(TEST_ELF) \
+                              $(LIBCRYPTO_SO) $(LIBSSL_SO)
 _NANVIX_GOALS := $(or $(MAKECMDGOALS),$(.DEFAULT_GOAL))
 
 # Ensure required variables are defined.
-_REQUIRED := PLATFORM \
-    PROCESS_MODE \
-    MEMORY_SIZE \
-    NANVIX_HOME \
-    NANVIX_TOOLCHAIN \
-    NANVIX_ROOT \
-    OUT_DIR \
-    DIST_DIR \
-    LIB_OUT \
-    INCLUDE_OUT \
-    TEST_OUT
+_REQUIRED := PLATFORM PROCESS_MODE MEMORY_SIZE NANVIX_HOME NANVIX_TOOLCHAIN
 ifneq ($(filter-out clean,$(_NANVIX_GOALS)),)
   $(foreach v,$(_REQUIRED),\
     $(if $($v),,$(error Required variable $v not set))\
@@ -101,9 +100,10 @@ CONFIGURE_OPTS = \
 	--openssldir="$(INSTALL_PREFIX)" \
 	--prefix="$(INSTALL_PREFIX)" \
 	nanvix \
-	no-shared \
+	shared \
+	no-pinshared \
+	enable-trace \
 	threads \
-	no-dso \
 	no-apps \
 	no-docs \
 	no-rdrand \
@@ -115,7 +115,7 @@ CONFIGURE_OPTS = \
 # Build Targets
 # ===========================================================================
 
-all: build $(TEST_ELF) install
+all: build $(LIBCRYPTO_SO) $(LIBSSL_SO) $(TEST_ELF)
 
 $(CONFIGURED_MARKER):
 	$(CONFIGURE_ENV) ./Configure $(CONFIGURE_OPTS)
@@ -123,6 +123,57 @@ $(CONFIGURED_MARKER):
 
 build: $(CONFIGURED_MARKER)
 	$(MAKE) -j$$(nproc) all
+	@# Strip bss_log.o so consumers can use --whole-archive libcrypto.a.
+	@# bss_log.o is the implementation of OpenSSL's BIO_s_log -- a syslog
+	@# BIO backend that we don't use and that references the POSIX
+	@# `openlog`/`syslog`/`closelog` symbols Nanvix newlib does not
+	@# provide.  Under normal archive selection nothing references
+	@# BIO_s_log so bss_log.o is never pulled; under --whole-archive
+	@# every member gets pulled and the link fails with three undefs.
+	@# Idempotent.
+	@if $(AR) t libcrypto.a 2>/dev/null | grep -q '^libcrypto-lib-bss_log\.o$$'; then \
+	  echo "  Stripping libcrypto-lib-bss_log.o from libcrypto.a"; \
+	  $(AR) d libcrypto.a libcrypto-lib-bss_log.o; \
+	  $(RANLIB) libcrypto.a; \
+	fi
+
+# Build libcrypto.so from the (PIC-clean) static archive.  OpenSSL's
+# x86 sources are already position-independent, so no -fPIC at compile
+# time is required.  libposix/libc/libm symbols are left UND and bind
+# at dlopen time against the host executable's .dynsym (same model
+# already used by libxml2.so / libffi.so on Nanvix).
+#
+# `-lgcc` is required because OpenSSL's bignum / hash arithmetic uses
+# 64-bit operations on 32-bit i686, and the resulting calls to libgcc
+# helpers (__udivdi3, __umoddi3, ...) cannot be resolved against the
+# host executable at dlopen time -- libgcc marks them hidden, so they
+# are absent from the host's .dynsym.  Embedding `-lgcc` ships those
+# leaf helpers inside libcrypto.so.  Only stateless arithmetic helpers
+# are pulled in; the structural check below asserts that no stateful
+# libgcc symbols (frame registry, unwinder, ifunc CPU dispatch state,
+# emutls, ...) leak in.
+$(LIBCRYPTO_SO): libcrypto.a
+	$(CC) -shared -fPIC -nostdlib \
+	    -Wl,-soname,libcrypto.so -Wl,-z,noexecstack \
+	    -Wl,--whole-archive libcrypto.a -Wl,--no-whole-archive \
+	    -lgcc \
+	    -o $@
+	@echo "  OK: $@ ($$(wc -c < $@) bytes)"
+	$(call check_no_stateful_libgcc,$@)
+
+# libssl.so depends on libcrypto.so via DT_NEEDED.  Order matters:
+# libcrypto.so must exist before libssl.so links, so the linker
+# resolves -lcrypto against the .so rather than the .a (which would
+# bundle libcrypto into libssl.so and defeat the deduplication).
+$(LIBSSL_SO): libssl.a $(LIBCRYPTO_SO)
+	$(CC) -shared -fPIC -nostdlib \
+	    -Wl,-soname,libssl.so -Wl,-z,noexecstack \
+	    -Wl,--whole-archive libssl.a -Wl,--no-whole-archive \
+	    -L. -lcrypto \
+	    -lgcc \
+	    -o $@
+	@echo "  OK: $@ ($$(wc -c < $@) bytes)"
+	$(call check_no_stateful_libgcc,$@)
 
 # Generate the inline test program source.
 $(TEST_SRC):
@@ -157,6 +208,82 @@ $(TEST_SRC):
 libcrypto.a libssl.a include/openssl/opensslv.h:
 	@echo "  FAIL: $@ not found; run 'build' first"; exit 1
 
+# Stateful libgcc symbols that MUST NOT be duplicated across DSOs in
+# a static-only environment (Nanvix does not ship libgcc_s.so).
+#
+# NOTE: this check is a WORKAROUND.  The long-term fix is to
+# eliminate the libgcc dependency from our .so files entirely (e.g.
+# by shipping a real libgcc_s.so for Nanvix, or by re-exporting the
+# helpers from the host executable's .dynsym via an explicit
+# `-Wl,-u<symbol> + visibility=default` wrapper).  Both are
+# substantially more involved than this regex check; the check
+# exists to fail-fast at build time on regressions while we work
+# towards the structural fix.
+#
+# Three tiers, all enforced equally:
+#
+# Tier 1 -- correctness-critical (crashes / wrong unwind / wrong CPU
+# dispatch / TLS aliasing / SjLj chain break):
+#   - Frame-registration registry (unwind-dw2-fde.c)
+#   - Core unwinder + _Unwind_Get*/Set* (unwind-dw2.c)
+#   - __gcc_personality_v0 / _sj0 (LSDA reader)
+#   - i386 CPU feature detection (__cpu_model / __cpu_features2 /
+#     __cpu_indicator_init)
+#   - emutls (emutls.c)
+#   - SjLj exception chain (unwind-sjlj.c)
+#
+# Tier 2 -- gcov profiling state (libgcov-driver.c).  Not currently
+# enabled on Nanvix, but listed to catch surprise enablement (e.g.
+# someone flips on -fprofile-arcs for a benchmark build):
+#   - __gcov_master / __gcov_error_file / __gcov_kvp_dynamic_pool*
+#   - __gcov_{init,exit,dump,reset} mutators
+#   - (__gcov_root is intentionally per-DSO; NOT blocked)
+#
+# Tier 3 -- split-stack state (generic-morestack*.c).  Not currently
+# enabled (Nanvix uses fixed stacks), but listed for the same reason
+# as Tier 2:
+#   - __morestack* / __generic_morestack* / __splitstack_*
+#
+# Regex is defined as a single physical line.  An earlier multi-line
+# form using GNU make backslash-continuation expanded to a regex
+# with embedded spaces between every alternative, which silently
+# matched nothing and turned the entire check into a no-op.
+LIBGCC_STATEFUL_RE := ^(__register_frame(_info(_bases|_table(_bases)?)?|_table)?|__deregister_frame(_info(_bases)?)?|__frame_state_for|_Unwind_(Find_FDE|RaiseException|Resume(_or_Rethrow)?|ForcedUnwind|Backtrace|DeleteException|FindEnclosingFunction|Get(GR|IP(Info)?|CFA|LanguageSpecificData|RegionStart|TextRelBase|DataRelBase)|Set(GR|IP))|__gcc_personality_(v0|sj0)|__cpu_(model|indicator_init|features2)|__emutls_(get_address|register_common)|_Unwind_SjLj_(Register|Unregister|RaiseException|ForcedUnwind|Resume(_or_Rethrow)?)|__gcov_(init|exit|dump|reset|master|error_file|kvp_dynamic_pool(_index|_size)?)|__morestack(_block_signals|_unblock_signals|_fail|_release_segments|_load_mmap|_allocate_stack_space|_segments|_current_segment|_initial_sp)?|__generic_(morestack(_set_initial_sp)?|releasestack|findstack)|__splitstack_(find|block_signals|getcontext|setcontext|makecontext|resetcontext|releasecontext|block_signals_context|find_context))$$
+
+# Assert that a .so does not contain any stateful libgcc symbols
+# across the three tiers defined above (Tier 1 correctness-critical,
+# Tier 2 gcov, Tier 3 split-stack) -- both defined and undefined,
+# because resolving a stateful symbol against a different DSO's copy
+# would still create the state-coherency hazard.
+#
+# $(1): path to the .so to check.
+define check_no_stateful_libgcc
+@echo "  Checking $(1) for stateful libgcc symbols..."
+@BAD_DEF=$$($(NANVIX_TOOLCHAIN)/bin/i686-nanvix-nm --defined-only $(1) 2>/dev/null \
+              | awk '{print $$NF}' | grep -E '$(LIBGCC_STATEFUL_RE)' || true); \
+ BAD_UND=$$($(NANVIX_TOOLCHAIN)/bin/i686-nanvix-nm --undefined-only $(1) 2>/dev/null \
+              | awk '{print $$NF}' | grep -E '$(LIBGCC_STATEFUL_RE)' || true); \
+ if [ -n "$$BAD_DEF" ]; then \
+   echo "  FAIL: $(1) bundles stateful libgcc symbols (defined):"; \
+   echo "$$BAD_DEF" | sed 's/^/    /'; \
+   echo "  These carry process-shared state and must not be"; \
+   echo "  duplicated across DSOs."; \
+   exit 1; \
+ fi; \
+ if [ -n "$$BAD_UND" ]; then \
+   echo "  FAIL: $(1) references stateful libgcc symbols (UND):"; \
+   echo "$$BAD_UND" | sed 's/^/    /'; \
+   echo "  These would resolve at dlopen time against whichever"; \
+   echo "  DSO loaded its own copy first, creating state-coherency"; \
+   echo "  hazards.  The fix is to export them from the host"; \
+   echo "  executable via an explicit -Wl,-u + visibility=default"; \
+   echo "  wrapper, or to remove the source dependency that pulled"; \
+   echo "  them in."; \
+   exit 1; \
+ fi; \
+ echo "  OK: $(1) free of stateful libgcc symbols"
+endef
+
 $(TEST_ELF): $(TEST_SRC) libcrypto.a libssl.a include/openssl/opensslv.h
 	$(CC) -O2 \
 	  -I$(CURDIR)/include \
@@ -165,14 +292,6 @@ $(TEST_ELF): $(TEST_SRC) libcrypto.a libssl.a include/openssl/opensslv.h
 	  $(NANVIX_LDFLAGS) $(NANVIX_LIBS) \
 	  -o $@
 
-# Stage built artifacts into the release/test output tree so that
-# `./z release` (which packages release_dir()) can find them.
-install: libcrypto.a libssl.a include/openssl/opensslv.h $(TEST_ELF)
-	@mkdir -p $(LIB_OUT) $(INCLUDE_OUT)/openssl $(TEST_OUT)
-	cp -f libcrypto.a libssl.a   $(LIB_OUT)/
-	cp -f include/openssl/*.h    $(INCLUDE_OUT)/openssl/
-	cp -f $(TEST_ELF)            $(TEST_OUT)/
-
 # ===========================================================================
 # Clean
 # ===========================================================================
@@ -180,6 +299,6 @@ install: libcrypto.a libssl.a include/openssl/opensslv.h $(TEST_ELF)
 clean:
 	-$(MAKE) clean 2>/dev/null || true
 	rm -f $(CONFIGURED_MARKER) $(TEST_SRC) $(TEST_ELF) Makefile
-	rm -rf $(OUT_DIR) dist/
+	rm -rf dist/
 
-.PHONY: all build install clean
+.PHONY: all build clean


### PR DESCRIPTION
## Summary

Produce position-independent `libcrypto.so` and `libssl.so` alongside the existing static `libcrypto.a` / `libssl.a`. The two .so files form a `DT_NEEDED` chain (`libssl.so -> libcrypto.so`) so consumers that need TLS only dlopen `libssl.so` once. `libposix` / `libc` / `libm` symbols are left UND and bound at dlopen time against the host executable's `.dynsym`, matching the extension-module model used elsewhere on Nanvix.

## What changes

| File | Change |
|---|---|
| `Makefile.nanvix` | Configure switches from a static-only build to the OpenSSL native `shared` + `no-pinshared` path; `enable-trace` is added so OpenSSL's internal trace facility is available for provider-load debugging on Nanvix. New `$(LIBCRYPTO_SO)` and `$(LIBSSL_SO)` targets link via `-shared -fPIC -nostdlib`, with `-Wl,-soname,<bare-name>`, `-Wl,-z,noexecstack`, `-lgcc`, and cross-library `-L. -lcrypto` for the `libssl.so -> libcrypto.so` edge. Each .so recipe runs the `check_no_stateful_libgcc` macro on its output so the structural check is part of artifact production, not piggy-backed on a later target. `test-functional` builds a small probe that exercises SHA256 + BIGNUM round-trips. `package` / `verify-package` ship and check both static archives plus both .so files. |
| `.nanvix/z.py` | Stages the new .so files via the `release` flow. |

## Why `-lgcc` on the .so link line

OpenSSL's bignum / hash arithmetic uses 64-bit operations on 32-bit i686, generating calls to libgcc helpers (`__udivdi3`, `__umoddi3`, ...). libgcc marks these helpers hidden, so they cannot resolve against the host executable's `.dynsym` at dlopen time. Embedding `-lgcc` ships those leaf helpers inside `libcrypto.so` and `libssl.so`.

Only stateless arithmetic helpers are safe to ship per-`.so`. Stateful libgcc symbols (frame registry, unwinder, ifunc CPU dispatch state, emutls, gcov, split-stack) would cause subtle state-coherency hazards if duplicated across DSOs. This PR includes a structural blocklist regex (`LIBGCC_STATEFUL_RE`) and a `check_no_stateful_libgcc` macro that fails the build at .so-link time if any blocklisted symbol is present (defined OR undefined) in either `.so`.

**Note on the regex:** `LIBGCC_STATEFUL_RE` is defined as a **single physical line**. An earlier multi-line form using GNU make backslash-continuation expanded to a regex with embedded spaces between every alternative, which silently matched nothing and turned the entire check into a no-op. The single-line form is verified to actually trigger on a planted test string before each release.

The long-term fix is to eliminate the libgcc dependency entirely (e.g. by shipping a real `libgcc_s.so` for Nanvix, or by re-exporting the helpers from the host executable's `.dynsym` via an explicit `-Wl,-u<symbol>` + `visibility=default` wrapper). Both are substantially more involved than this regex check; the check exists to fail-fast on regressions while the structural fix is being designed.

## Why bare SONAMEs (`libcrypto.so`, `libssl.so`, not `libcrypto.so.3`)

Upstream OpenSSL 3.x ships SONAME `libcrypto.so.3` / `libssl.so.3` -- the `SHLIB_VERSION_NUMBER` baked into the API. The Nanvix port uses the bare names because Nanvix is currently single-vendor: every consumer is built in this monorepo against this exact OpenSSL version, and Nanvix has no `LD_LIBRARY_PATH`-style runtime version search. If a third-party consumer ever needs the versioned names, the `package` target can install `libcrypto.so.3 -> libcrypto.so` and `libssl.so.3 -> libssl.so` symlinks as a follow-up; that change is non-load-bearing for current consumers and intentionally out of scope here.

## Runtime dependencies

All three of the following must be in place for any consumer's dlopen of `libssl.so` / `libcrypto.so` to actually work:

- [nanvix/nanvix#2473](https://github.com/nanvix/nanvix/pull/2473) -- `DT_RUNPATH` + `.init_array` invocation. OpenSSL relies on `.init_array` constructors that the current loader silently skips.
- [nanvix/nanvix#2478](https://github.com/nanvix/nanvix/pull/2478) -- diamond `DT_NEEDED` handling. The OpenSSL .so chain forms a diamond at runtime when more than one consumer ELF dlopens `libcrypto.so` (e.g. `_ssl.so` + `_hashlib.so` in a Python interpreter).
- [nanvix/nanvix#2481](https://github.com/nanvix/nanvix/pull/2481) -- **critical**: `pthread_once` + `pthread_key_create` destructor support. OpenSSL routes every internal one-time init through `pthread_once`; without #2481 every `EVP_*` / `SSL_*` call silently fails with `OPENSSL_init_crypto` returning 0 / `EVP_MD_fetch` returning NULL / `SSL_CTX_new` returning NULL with an empty error queue.

## Known follow-ups (out of scope here)

- **Versioned SONAME symlinks** (`libcrypto.so.3 -> libcrypto.so`, etc.) for third-party portability.
- **`verify-package` ELF validation**: assert `SONAME`, `DT_NEEDED libcrypto.so` in `libssl.so` (and absent from `libcrypto.so`), and well-known exports (`T EVP_MD_fetch`, `T OSSL_PROVIDER_load`, `T SSL_CTX_new`, `T SSL_new`) via `nm -D`. Mirrors the libxml2 sibling pattern; can be added in a follow-up once consumer-side dlopen validation lands.
- **Configure flag enumeration**: `enable-trace` and the removal of `no-dso` are documented above; a follow-up to fully audit the Configure delta vs upstream OpenSSL 3.5 would be appropriate before declaring API stability.
- **`-nostdlib` validation**: confirm `DT_INIT_ARRAY` / `DT_INIT_ARRAYSZ` and `.eh_frame_hdr` are present in each `.so`. Modern `ld` synthesises these from the linker script and the Nanvix loader iterates `INIT_ARRAY` directly, so this is expected to work; the verify step is a follow-up belt-and-suspenders.

## Validation

`./z build` produces `libcrypto.so` (~5.5 MB) and `libssl.so` (~1.4 MB). The `check_no_stateful_libgcc` macro runs as part of each .so recipe and reports `OK: ... free of stateful libgcc symbols` for both. `test-functional` passes (`OPENSSL_TEST: PASS version=OpenSSL 3.5.x ...`).
