### PR TITLE
[build] E: Link libnvx_crt0.a into test ELF

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -83,6 +83,7 @@ RANLIB := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-ranlib
 CXX := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-g++
 NANVIX_LDFLAGS := -T$(SYSROOT_PATH)/lib/user.ld -static -Wl,-z,noexecstack
 NANVIX_LIBS := -Wl,--start-group \
+  $(SYSROOT_PATH)/lib/libnvx_crt0.a \
   $(SYSROOT_PATH)/lib/libposix.a \
   $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libc.a \
   $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libm.a \


### PR DESCRIPTION
## Summary

[nanvix/nanvix#2453](https://github.com/nanvix/nanvix/pull/2453) (already upstream) moved the `_start` entry point out of `libposix.a` into a new `libnvx_crt0.a`. Add `libnvx_crt0.a` to the test ELF link line so the linker resolves `_start` from it; without this the linker silently picks newlib's weak default `_start` and the test hangs at startup with no diagnostic output.

## Dependencies

This PR assumes the following have already merged and the toolchain image has been republished:

- [nanvix/nanvix#2487](https://github.com/nanvix/nanvix/pull/2487) — `sys-ffi` crate split that removes the duplicate `__kcall_*` / `_do_exit_thread` / `_do_start_thread` strong symbols from `libnvx_crt0.a`.
- [nanvix/newlib#17](https://github.com/nanvix/newlib/pull/17) — declares newlib's `_do_start` as `.weak` so `libnvx_crt0`'s strong SSE-aligned override wins cleanly without `-Wl,--allow-multiple-definition`.
- [nanvix/toolchain-gcc#14](https://github.com/nanvix/toolchain-gcc/pull/14) — pins the new newlib commit and triggers a republish of `ghcr.io/nanvix/toolchain-gcc`.

If those have not landed, the link line will fail with `multiple definition of __kcall_*` errors against the unpatched toolchain image.

## What changes

One line added to the test ELF link line: `$(SYSROOT_PATH)/lib/libnvx_crt0.a` placed inside the existing `--start-group` ahead of `libposix.a`, so the linker resolves `_start` from libnvx_crt0's strong symbol.
