### PR TITLE
[sdk] E: Remove duplicate image pin

### DIFF
--- a/.nanvix/NANVIX.md
+++ b/.nanvix/NANVIX.md
@@ -98,8 +98,8 @@ WHEEL_URL=$(gh api repos/nanvix/zutils/releases/latest \
   --jq '.assets[] | select(.name | endswith(".whl")) | .browser_download_url')
 pip install "$WHEEL_URL"
 
-# Setup runtime sysroot and select the pinned SDK image
-./z setup --with-docker ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f
+# Setup the runtime sysroot and manifest-pinned SDK image.
+./z setup
 ./z build
 ```
 
@@ -116,7 +116,7 @@ make -f Makefile.nanvix \
 
 The SDK Clang driver selects the Nanvix headers, libc, compiler runtime,
 startup objects, and linker script. The downloaded sysroot is runtime-only.
-SDK v0.20.0-sdk.1 also includes Perl and `FindBin`, so no derived OpenSSL
+The manifest-pinned SDK also includes Perl and `FindBin`, so no derived OpenSSL
 builder image is needed.
 
 ### Build Outputs

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -53,12 +53,6 @@ _MAKE_VAR_INSTALL_PREFIX = "INSTALL_PREFIX"
 # Use /sysroot so that release tarballs don't contain ephemeral runner paths.
 _DEFAULT_INSTALL_PREFIX = "/sysroot"
 
-# Docker image for cross-compilation (Nanvix SDK v0.20.0-sdk.1).
-_DOCKER_IMAGE = (
-    "ghcr.io/nanvix/nanvix-sdk-c-clang"
-    "@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
-)
-
 # Test binary name produced by the Makefile.
 _TEST_ELF = "openssl_nanvix_test.elf"
 
@@ -125,10 +119,6 @@ class OpenSSLBuild(ZScript):
         "bin/kernel.elf",
         "bin/mkramfs.exe",
     )
-
-    def docker_image(self) -> str:
-        """Return the Docker image for cross-compilation."""
-        return _DOCKER_IMAGE
 
     def docker_config(self, image: str) -> DockerConfig:
         """Extend the default Docker config with build outputs.


### PR DESCRIPTION
Remove the dead z.py image override and document manifest-derived setup. Lint and strict typing pass.