### PR TITLE
[ci] E: Update nanvix workflow refs to v3.0.4

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v3.0.3
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v3.0.4
     with:
       platforms: '["microvm"]'
       process-modes: '["standalone"]'
@@ -41,7 +41,7 @@ jobs:
 
   ci-scheduled:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v3.0.3
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v3.0.4
     with:
       platforms: '["microvm"]'
       process-modes: '["standalone"]'


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v3.0.4`](https://github.com/nanvix/workflows/releases/tag/v3.0.4).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.